### PR TITLE
Option to prevent rationale dialog from being cancelled by the user

### DIFF
--- a/permissions/src/main/java/com/nabinbhandari/android/permissions/Permissions.java
+++ b/permissions/src/main/java/com/nabinbhandari/android/permissions/Permissions.java
@@ -152,9 +152,12 @@ public class Permissions {
 
         String settingsText = "Settings";
         String rationaleDialogTitle = "Permissions Required";
+        String rationaleDialogNegativeButton = null;
+        String rationaleDialogPositiveButton = null;
         String settingsDialogTitle = "Permissions Required";
         String settingsDialogMessage = "Required permission(s) have been set" +
                 " not to ask again! Please provide them from settings.";
+        boolean rationaleDialogCancelable = true;
         boolean sendBlockedToSettings = true;
         boolean createNewTask = false;
 
@@ -194,6 +197,28 @@ public class Permissions {
         }
 
         /**
+         * Sets a custom text for the rationale dialog's negative button.
+         *
+         * @param rationaleDialogNegativeButton cancel button text.
+         * @return same instance.
+         */
+        public Options setRationaleDialogNegativeButton(String rationaleDialogNegativeButton) {
+            this.rationaleDialogNegativeButton = rationaleDialogNegativeButton;
+            return this;
+        }
+
+        /**
+         * Sets a custom text for the rationale dialog's positive button.
+         *
+         * @param rationaleDialogPositiveButton positive button text.
+         * @return same instance.
+         */
+        public Options setRationaleDialogPositiveButton(String rationaleDialogPositiveButton) {
+            this.rationaleDialogPositiveButton = rationaleDialogPositiveButton;
+            return this;
+        }
+
+        /**
          * Sets the title text of the dialog which asks user to go to settings, in the case when
          * permission(s) have been set not to ask again.
          *
@@ -228,6 +253,17 @@ public class Permissions {
          */
         public Options sendDontAskAgainToSettings(boolean send) {
             sendBlockedToSettings = send;
+            return this;
+        }
+
+        /**
+         * Sets whether or not the rationale dialog should be cancelable.
+         *
+         * @param cancelable if true, the rationale dialog will be cancelable.
+         * @return same instance.
+         */
+        public Options setRationaleDialogCancelable(boolean cancelable) {
+            rationaleDialogCancelable = cancelable;
             return this;
         }
     }

--- a/permissions/src/main/java/com/nabinbhandari/android/permissions/PermissionsActivity.java
+++ b/permissions/src/main/java/com/nabinbhandari/android/permissions/PermissionsActivity.java
@@ -92,16 +92,26 @@ public class PermissionsActivity extends Activity {
                 }
             }
         };
-        new AlertDialog.Builder(this).setTitle(options.rationaleDialogTitle)
-                .setMessage(rationale)
-                .setPositiveButton(android.R.string.ok, listener)
-                .setNegativeButton(android.R.string.cancel, listener)
-                .setOnCancelListener(new DialogInterface.OnCancelListener() {
-                    @Override
-                    public void onCancel(DialogInterface dialog) {
-                        deny();
-                    }
-                }).create().show();
+
+        AlertDialog.Builder builder = new AlertDialog.Builder(this).setTitle(options.rationaleDialogTitle);
+        builder.setMessage(rationale);
+
+        if(options.rationaleDialogCancelable){
+            String negativeButtonText = options.rationaleDialogNegativeButton != null ? options.rationaleDialogNegativeButton : getString(android.R.string.cancel);
+            builder.setNegativeButton(negativeButtonText, listener)
+                    .setOnCancelListener(new DialogInterface.OnCancelListener() {
+                        @Override
+                        public void onCancel(DialogInterface dialog) {
+                            deny();
+                        }
+                    });
+        } else {
+            builder.setCancelable(false);
+        }
+
+        String positiveButtonText = options.rationaleDialogPositiveButton != null ? options.rationaleDialogPositiveButton : getString(android.R.string.ok);
+        builder.setPositiveButton(positiveButtonText, listener)
+                .create().show();
     }
 
     @SuppressWarnings("NullableProblems")

--- a/permissions/src/main/java/com/nabinbhandari/android/permissions/PermissionsActivity.java
+++ b/permissions/src/main/java/com/nabinbhandari/android/permissions/PermissionsActivity.java
@@ -96,7 +96,7 @@ public class PermissionsActivity extends Activity {
         AlertDialog.Builder builder = new AlertDialog.Builder(this).setTitle(options.rationaleDialogTitle);
         builder.setMessage(rationale);
 
-        if(options.rationaleDialogCancelable){
+        if (options.rationaleDialogCancelable) {
             String negativeButtonText = options.rationaleDialogNegativeButton != null ? options.rationaleDialogNegativeButton : getString(android.R.string.cancel);
             builder.setNegativeButton(negativeButtonText, listener)
                     .setOnCancelListener(new DialogInterface.OnCancelListener() {


### PR DESCRIPTION
Hi,

I had a scenario in my App, where the user would keep getting the rationale dialog over and over again for each attempt to run a specific action that required a certain permission (if denied). When the user hit "cancel" in the rationale dialog, neither the system nor the Android-Permissions library would keep any persisted record of the denial. Thus I needed to force the user to continue to the system permission request dialog, so that the system could mark the permission as permanently denied (when denied again), and automatically respond with denial for any further requests.

For this I introduced an option to control whether or not the rationale dialog should be cancelable or not. Along with this option I also added options to provide text for the rationale dialog's buttons. I used this in my app to change the positive button to "Continue".